### PR TITLE
Fixes to remember serial settings

### DIFF
--- a/render/src/lib/services/service.ts
+++ b/render/src/lib/services/service.ts
@@ -266,8 +266,17 @@ export class Service extends Toolkit.APluginService {
         this._session
       )
       .then(() => {
-        this.writeConfig(EType.options, options);
-
+        this.writeConfig(EType.options, options)
+          .then(() => {
+            if (this._configSettings !== undefined) {
+              this._configSettings[options.path] = options;
+            }
+          })
+          .catch((error: Error) => {
+            this._logger.error(
+              `Failed to update settings for port ${options.path} due to error: ${error.message}`
+            );
+          });
         const cSessionPort = this._sessionPort[this._session];
         if (cSessionPort !== undefined && cSessionPort[options.path]) {
           cSessionPort[options.path].connected = true;
@@ -317,6 +326,9 @@ export class Service extends Toolkit.APluginService {
   public requestPorts(session?: string): Promise<any> {
     if (session === undefined) {
       session = this._session;
+    }
+    if (session === "*") {
+      return new Promise((resolve) => resolve(true));
     }
     return this._api
       .getIPC()

--- a/render/src/lib/views/sidebar.vertical/component.ts
+++ b/render/src/lib/views/sidebar.vertical/component.ts
@@ -119,8 +119,13 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
   }
 
   private _updatePortsList() {
+    let empty_session: boolean;
     Service.requestPorts()
       .then((response) => {
+        if (response === true) {
+          empty_session = response;
+          return;
+        }
         this._ng_detectionError = false;
         this._updatePorts(response.ports);
       })
@@ -133,6 +138,9 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
         );
       })
       .finally(() => {
+        if (empty_session === true) {
+          return;
+        }
         setTimeout(() => {
           this._updatePortsList();
         }, 3500);


### PR DESCRIPTION
Fix for ticket #1368
- Remember settings for serial port after connecting
- Get rid of error messages when opening "About" tab